### PR TITLE
Small improvements - logging

### DIFF
--- a/src/Date.js
+++ b/src/Date.js
@@ -26,5 +26,5 @@ export function yyyymmdd() {
 export function hhmmss() {
   const [, , , hours, minutes, seconds] = date();
 
-  return [hours, minutes, seconds].join("/");
+  return [hours, minutes, seconds].join(":");
 }

--- a/src/Logger.purs
+++ b/src/Logger.purs
@@ -21,7 +21,7 @@ withTimestamp :: String -> Effect String
 withTimestamp message = do
   date <- yyyymmdd
   hour <- hhmmss
-  pure $ darkgray <> date <> " " <> hour <> clear <> " " <> message
+  pure $ dim <> date <> " " <> hour <> clear <> " " <> message
 
 lines :: String -> Array String
 lines = split (Pattern "\n")
@@ -44,8 +44,8 @@ quote = (traverse_ (logWithTimestamp <<< format Empty)) <<< lines
 format :: Format -> String -> String
 format Info message = bold <> blue <> "info " <> clear <> message <> clear
 format Error message = bold <> red <> "err  " <> clear <> message <> clear
-format Log message = darkgray <> message <> clear
-format Empty message = "     " <> darkgray <> message <> clear
+format Log message = dim <> message <> clear
+format Empty message = "     " <> dim <> message <> clear
 
 code :: String -> String
 code a = "\x1b[" <> a <> "m"
@@ -62,8 +62,8 @@ blue = code "34"
 bold :: String
 bold = code "1"
 
-darkgray :: String
-darkgray = code "90"
+dim :: String
+dim = code "2"
 
 clear :: String
 clear = code "0"


### PR DESCRIPTION
## Fix 1: Colors 

Dimming text instead of using darkgray in non standard execution environments is more readable (i.e. compilation buffer in emacs). It also slightly improves readability in a regular terminal environment.

| Emacs: Before | Emacs: After |
|:-:|:-:|
| <img width="500" alt="before" src="https://user-images.githubusercontent.com/90652/223867283-cd565a6b-9680-400c-9f13-b32be81eb889.png"> | <img width="500" alt="after" src="https://user-images.githubusercontent.com/90652/223867280-889f87f7-1683-4be6-9e3c-19516ee09817.png"> |
| **Terminal: Before** | **Terminal: After** |
| <img width="500" alt="before" src="https://user-images.githubusercontent.com/90652/223867715-611c1742-cbcf-4fa2-97e0-0ecacbaad600.png"> | <img width="500" alt="after" src="https://user-images.githubusercontent.com/90652/223867717-0aba031a-a8e0-4eb1-ac05-91c721f14656.png"> |

## Fix 2: Time formatting

After refactoring of the Date.js module, the time was incorrectly formatted using `/` separator instead of `:`

| Before | After |
|:-:|:-:|
| <img width="500" alt="before" src="https://user-images.githubusercontent.com/90652/223868424-75fcf7de-cf79-47f2-a577-dc8e84fa4b07.png"> | <img width="500" alt="after" src="https://user-images.githubusercontent.com/90652/223868416-3ccaac5a-1d4f-4740-bce8-c143057ad7bc.png"> |
